### PR TITLE
feat!: Renames api-method-should-specify-api-operation rule to api-method-should-specify-api-response

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Nest Swagger
 
 -   api-property-matches-property-optionality
 -   controllers-should-supply-api-tags
--   api-method-should-specify-api-operation
+-   api-method-should-specify-api-response
 -   api-enum-property-best-practices
 -   api-property-returning-array-should-set-array
 
@@ -162,24 +162,23 @@ The following FAILS because it's missing api tags
 class TestClass {}
 ```
 
-### Rule: api-method-should-specify-api-operation
+### Rule: api-method-should-specify-api-response
 
-If you have an api method like @Get() you should specify the return status code (and type!) by using @ApiOkResponse and the other expected responses. I often leave out 400s and 500s because it's kind of assumed but they should be used if the return type changes!
+If you have an api method like @Get() you should specify the return status code (and type!) by using @ApiResponse and the other expected responses. I often leave out 400s and 500s because it's kind of assumed but they should be used if the return type changes!
 
 This PASSES
 
 ```ts
 class TestClass {
     @Get()
-    @ApiOkResponse({type: String, isArray: true})
-    @ApiBadRequestResponse({description: "Bad Request"})
+    @ApiResponse({status: 200, type: String})
     public getAll(): Promise<string[]> {
         return [];
     }
 }
 ```
 
-The following FAILS because it's missing api operation decorators
+The following FAILS because it's missing api response decorators
 
 ```ts
 class TestClass {

--- a/src/configs/noSwagger.ts
+++ b/src/configs/noSwagger.ts
@@ -5,7 +5,7 @@ export = {
     rules: {
         "@darraghor/nestjs-typed/api-property-matches-property-optionality":
             "off",
-        "@darraghor/nestjs-typed/api-method-should-specify-api-operation":
+        "@darraghor/nestjs-typed/api-method-should-specify-api-response":
             "off",
         "@darraghor/nestjs-typed/controllers-should-supply-api-tags": "off",
         "@darraghor/nestjs-typed/api-enum-property-best-practices": "off",

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -14,7 +14,7 @@ export = {
         ],
         "@darraghor/nestjs-typed/api-property-matches-property-optionality":
             "error",
-        "@darraghor/nestjs-typed/api-method-should-specify-api-operation":
+        "@darraghor/nestjs-typed/api-method-should-specify-api-response":
             "error",
         "@darraghor/nestjs-typed/controllers-should-supply-api-tags": "error",
         "@darraghor/nestjs-typed/api-enum-property-best-practices": "error",

--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test-data.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test-data.ts
@@ -30,7 +30,7 @@ export const testCases = [
             }
         }`,
         shouldUseDecorator: true,
-        message: "no api operation decorator",
+        message: "no api respones decorator",
     },
     {
         moduleCode: `class TestClass {

--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test-data.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test-data.ts
@@ -14,6 +14,17 @@ export const testCases = [
     {
         moduleCode: `class TestClass {
             @Get()
+            @ApiResponse({ status: 200, type: String })
+            public getAll(): Promise<string[]> {
+                return [];
+            }
+        }`,
+        shouldUseDecorator: false,
+        message: "all good",
+    },
+    {
+        moduleCode: `class TestClass {
+            @Get()
             public getAll(): Promise<string[]> {
                 return [];
             }

--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test.ts
@@ -4,11 +4,11 @@ import {
     fakeFilePath,
 } from "../../utils/nestModules/nestProvidedInjectableMapper.test-date";
 import {TSESTree} from "@typescript-eslint/types";
-import {testCases} from "./apiMethodsShouldSpecifyApiOperation.test-data";
-import {shouldUseApiOperationDecorator} from "./apiMethodsShouldSpecifyApiOperation";
+import {testCases} from "./apiMethodsShouldSpecifyApiResponse.test-data";
+import {shouldUseApiResponseDecorator} from "./apiMethodsShouldSpecifyApiResponse";
 
 // should probably be split up into multiple tests
-describe("apiMethodsShouldSpecifyApiOperation", () => {
+describe("apiMethodsShouldSpecifyApiResponse", () => {
     test.each(testCases)(
         "is an expected response for %#",
         (testCase: {
@@ -22,7 +22,7 @@ describe("apiMethodsShouldSpecifyApiOperation", () => {
                 fakeContext
             );
 
-            const shouldUseOptional = shouldUseApiOperationDecorator(
+            const shouldUseOptional = shouldUseApiResponseDecorator(
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (ast.body[0] as TSESTree.ClassDeclaration).body
                     .body[0] as TSESTree.MethodDefinition

--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
@@ -5,7 +5,7 @@ import {TSESTree} from "@typescript-eslint/types";
 import {createRule} from "../../utils/createRule";
 import {typedTokenHelpers} from "../../utils/typedTokenHelpers";
 
-export const shouldUseApiOperationDecorator = (
+export const shouldUseApiResponseDecorator = (
     node: TSESTree.MethodDefinition
 ): boolean => {
     const hasApiMethodDecorator = typedTokenHelpers.nodeHasDecoratorsNamed(
@@ -13,7 +13,7 @@ export const shouldUseApiOperationDecorator = (
         ["Get", "Post", "Put", "Delete", "Patch", "Options", "Head", "All"]
     );
 
-    const hasApiOperationDecorator = typedTokenHelpers.nodeHasDecoratorsNamed(
+    const hasApiResponseDecorator = typedTokenHelpers.nodeHasDecoratorsNamed(
         node,
         [
             "ApiResponse",
@@ -46,11 +46,11 @@ export const shouldUseApiOperationDecorator = (
         ]
     );
 
-    return hasApiMethodDecorator && !hasApiOperationDecorator;
+    return hasApiMethodDecorator && !hasApiResponseDecorator;
 };
 
 const rule = createRule({
-    name: "api-method-should-specify-api-operation",
+    name: "api-method-should-specify-api-response",
     meta: {
         docs: {
             description:
@@ -60,7 +60,7 @@ const rule = createRule({
             requiresTypeChecking: false,
         },
         messages: {
-            shouldSpecifyApiOperation: `A method decorated with @Get, @Post etc. should specify the expected ApiOperation e.g. @ApiOkResponse(type: MyType)`,
+            shouldSpecifyApiResponse: `A method decorated with @Get, @Post etc. should specify the expected ApiResponse e.g. @ApiOkResponse(type: MyType)`,
         },
         schema: [],
         type: "suggestion",
@@ -71,10 +71,10 @@ const rule = createRule({
         return {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             MethodDefinition(node: TSESTree.MethodDefinition): void {
-                if (shouldUseApiOperationDecorator(node)) {
+                if (shouldUseApiResponseDecorator(node)) {
                     context.report({
                         node: node,
-                        messageId: "shouldSpecifyApiOperation",
+                        messageId: "shouldSpecifyApiResponse",
                     });
                 }
             },

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -2,7 +2,7 @@ import injectableShouldBeProvided from "./injectablesShouldBeProvided/injectable
 import providedInjectedShouldMatchFactoryParameters from "./providerInjectedShouldMatchFactory/ProviderInjectedShouldMatchFactory";
 import apiPropertyMatchesPropertyOptionality from "./apiPropertyMatchesPropertyOptionality/apiPropertyMatchesPropertyOptionality";
 import controllerDecoratedHasApiTags from "./controllerDecoratedHasApiTags/controllerDecoratedHasApiTags";
-import apiMethodsShouldSpecifyApiOperation from "./apiMethodsShouldSpecifyApiOperation/apiMethodsShouldSpecifyApiOperation";
+import apiMethodsShouldSpecifyApiResponse from "./apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse";
 import apiEnumPropertyBestPractices from "./apiEnumPropertyBestPractices/apiEnumPropertyBestPractices";
 import apiPropertyReturningArrayShouldSetArray from "./apiPropertyReturningArrayShouldSetArray/apiPropertyReturningArrayShouldSetArray";
 
@@ -13,8 +13,8 @@ const allRules = {
     "provided-injected-should-match-factory-parameters":
         providedInjectedShouldMatchFactoryParameters,
     "controllers-should-supply-api-tags": controllerDecoratedHasApiTags,
-    "api-method-should-specify-api-operation":
-        apiMethodsShouldSpecifyApiOperation,
+    "api-method-should-specify-api-response":
+    apiMethodsShouldSpecifyApiResponse,
     "api-enum-property-best-practices": apiEnumPropertyBestPractices,
     "api-property-returning-array-should-set-array":
         apiPropertyReturningArrayShouldSetArray,


### PR DESCRIPTION
BREAKING CHANGE: renames a rule