### PR TITLE
fix(rules): Added additional support for mixed quotes in paramDecorat…

### DIFF
--- a/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.test.ts
+++ b/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.test.ts
@@ -118,11 +118,55 @@ ruleTester.run("param-decorator-name-matches-route-param", rule, {
             `,
         },
         {
+            // mix quote support test
+            code: `
+            @ApiTags("Custom Bot")
+            @ApiBearerAuth()
+            @UseGuards(DefaultAuthGuard)
+            @Controller('custom-bot/:uuid/my-controller')
+            export class CustomBotController {
+                constructor(
+                ) {}
+            
+                @Get()
+                @ApiOkResponse({ type: CustomBot })
+                findOne(
+                    @Param("uuid") uuid: string,
+                    @Request() request: RequestWithUser
+                ): Promise<CustomBot> {
+                    return this.customBotService.findOne(uuid, request.user.uuid);
+                }
+            }
+            `,
+        },
+        {
             code: `
             @ApiTags("Custom Bot")
             @ApiBearerAuth()
             @UseGuards(DefaultAuthGuard)
             @Controller({path:"custom-bot/:uuid/my-controller"})
+            export class CustomBotController {
+                constructor(
+                ) {}
+            
+                @Get()
+                @ApiOkResponse({ type: CustomBot })
+                findOne(
+                    @Param("uuid") uuid: string,
+                    @Request() request: RequestWithUser
+                ): Promise<CustomBot> {
+                    return this.customBotService.findOne(uuid, request.user.uuid);
+                }
+            }
+            `,
+        },
+        {
+            // mix quote support test
+            code: `
+            @ApiTags("Custom Bot")
+            @ApiBearerAuth()
+            @UseGuards(DefaultAuthGuard)
+            @Controller({path:'custom-bot/:uuid/my-controller'})
             export class CustomBotController {
                 constructor(
                 ) {}

--- a/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.ts
+++ b/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.ts
@@ -77,7 +77,9 @@ export const isParameterNameIncludedInAPathPart = (
             pathPart === `':${paramName}'` ||
             pathPart.includes(`/:${paramName}/`) ||
             pathPart.includes(`/:${paramName}"`) ||
-            pathPart.includes(`":${paramName}/`)
+            pathPart.includes(`":${paramName}/`) ||
+            pathPart.includes(`/:${paramName}'`) ||
+            pathPart.includes(`':${paramName}/`)
         );
     });
 };


### PR DESCRIPTION
…orNameMatchesRouteParam

Addressed issue where mixed quote route parameter failed lint test
e.g. 'download/:id' vs "download/:id"