### PR TITLE
fix: missing null-check in `apiPropertyReturningArrayShouldSetArray`

### DIFF
--- a/src/rules/apiPropertyReturningArrayShouldSetArray/apiPropertyReturningArrayShouldSetArray.test.ts
+++ b/src/rules/apiPropertyReturningArrayShouldSetArray/apiPropertyReturningArrayShouldSetArray.test.ts
@@ -26,6 +26,12 @@ ruleTester.run("api-property-returning-array-should-set-array", rule, {
                 @ApiPropertyOptional({isArray:true})
                 thisIsAStringProp?: Array<string>;}`,
         },
+        {
+            code: `class TestClass {
+                @Expose()
+                @ApiPropertyOptional()
+                thisIsABooleanProp = false}`,
+        },
     ],
     invalid: [
         {

--- a/src/rules/apiPropertyReturningArrayShouldSetArray/apiPropertyReturningArrayShouldSetArray.ts
+++ b/src/rules/apiPropertyReturningArrayShouldSetArray/apiPropertyReturningArrayShouldSetArray.ts
@@ -26,14 +26,16 @@ export const shouldSetArrayProperty = (
             "isArray",
             true
         );
+
+    const typeAnnotation = node.typeAnnotation?.typeAnnotation;
     // handle string[] or Array<string>
     const isArrayType =
         (
-            (node.typeAnnotation?.typeAnnotation as TSESTree.TSTypeReference)
-                .typeName as TSESTree.Identifier
+            (typeAnnotation as TSESTree.TSTypeReference | undefined)
+                ?.typeName as TSESTree.Identifier
         )?.name === "Array";
     const isTypescriptArrayType =
-        node.typeAnnotation?.typeAnnotation.type === AST_NODE_TYPES.TSArrayType;
+        typeAnnotation?.type === AST_NODE_TYPES.TSArrayType;
     const isAnArrayLikeType = isArrayType || isTypescriptArrayType;
 
     return new ArraySetResultModel(


### PR DESCRIPTION
This PR fixes a missing null-check causing crashes of ESLint.
The error occurs when trying to lint a class containg an infered field type.
In the below example, the explicit type `boolean` is optional if the default value is set to `false`:

```ts
class TestClass {
    @Expose()
    @ApiPropertyOptional()
    thisIsABooleanProp = false;
}
```