### PR TITLE
fix: Remove noisy console.log

### DIFF
--- a/src/rules/validate-non-primitves-needs-type-decorator/validateNonPrimitiveNeedsDecorators.ts
+++ b/src/rules/validate-non-primitves-needs-type-decorator/validateNonPrimitiveNeedsDecorators.ts
@@ -150,8 +150,6 @@ const rule = createRule({
                 }
 
                 // we add the supplied extra decorators from settings to the type decorators
-
-                console.log(`deccc ${additionalTypeDecorators.flat(1)}`);
                 const typeDecorators = new Array<string>().concat(
                     additionalTypeDecorators, // these are user-specified extra type decorators, unique to user's project
                     ["Type"] //this is the default type decorator


### PR DESCRIPTION
Love this repo — thanks!

I noticed my console was getting flooded with `deccc` during linting from  the `validate-non-primitves-needs-type-decorator` rule. Looks like an unnecessary `console.log` statement used for debugging slipped through the net.

This tiny PR removes it.