### PR TITLE
feat: autofix suggestions for validateNonPrimitiveNeedsDecorators

### DIFF
--- a/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
+++ b/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
@@ -319,6 +319,25 @@ class Foo {
             ],
         },
         {
+            // is an array with union - should have type
+            code: `
+                import { ValidateNested, IsArray } from 'class-validator';
+                
+                export class CreateOrganisationDto {
+                    @ApiProperty({ type: Person, isArray: true })
+                    @ValidateNested({each:true})
+                    @IsArray()
+                    members!: (Person&Date)[];
+                }
+        `,
+            errors: [
+                {
+                    messageId: "shouldUseTypeDecorator",
+                    suggestions: [],
+                },
+            ],
+        },
+        {
             // is not a primitive type
             code: `
                 import { ValidateNested, IsDate } from 'class-validator';

--- a/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
+++ b/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
@@ -212,6 +212,7 @@ class Foo {
                     suggestions: [
                         {
                             messageId: "autofixWithTypeDecorator",
+                            data: {typeIdentifier: "Foo"},
                             output: `
             import { ValidateNested } from 'class-validator';
             
@@ -245,6 +246,7 @@ class Foo {
                     suggestions: [
                         {
                             messageId: "autofixWithTypeDecorator",
+                            data: {typeIdentifier: "Foo"},
                             output: `
             import { ValidateNested } from 'class-validator';
             
@@ -280,6 +282,7 @@ class Foo {
                     suggestions: [
                         {
                             messageId: "autofixWithTypeDecorator",
+                            data: {typeIdentifier: "Foo"},
                             output: `
             import { ValidateNested } from 'class-validator';
             
@@ -333,6 +336,7 @@ class Foo {
                     suggestions: [
                         {
                             messageId: "autofixWithTypeDecorator",
+                            data: {typeIdentifier: "Date"},
                             output: `
                 import { ValidateNested, IsDate } from 'class-validator';
                 
@@ -366,6 +370,7 @@ class Foo {
                     suggestions: [
                         {
                             messageId: "autofixWithTypeDecorator",
+                            data: {typeIdentifier: "CustomClass"},
                             output: `
                 import { ValidateNested, IsDefined } from 'class-validator';
                 

--- a/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
+++ b/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
@@ -209,6 +209,20 @@ class Foo {
             errors: [
                 {
                     messageId: "shouldUseTypeDecorator",
+                    suggestions: [
+                        {
+                            messageId: "autofixWithTypeDecorator",
+                            output: `
+            import { ValidateNested } from 'class-validator';
+            
+            export class CreateOrganisationDto {
+                @Type(() => Foo)@ApiProperty({ type: Person, isArray: true })
+                @ValidateNested({each:true})
+                members!: Foo[];
+            }
+    `,
+                        },
+                    ],
                 },
             ],
         },
@@ -228,6 +242,57 @@ class Foo {
             errors: [
                 {
                     messageId: "shouldUseTypeDecorator",
+                    suggestions: [
+                        {
+                            messageId: "autofixWithTypeDecorator",
+                            output: `
+            import { ValidateNested } from 'class-validator';
+            
+            export class Foo {}
+            
+            export class CreateOrganisationDto {
+                @Type(() => Foo)@ApiProperty({ type: Person, isArray: true })
+                @ValidateNested({each:true})
+                members?: Foo[];
+            }
+    `,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            // is an Array<> declared array - should have type
+            code: `
+            import { ValidateNested } from 'class-validator';
+            
+            export class Foo {}
+            
+            export class CreateOrganisationDto {
+                @ApiProperty({ type: Person, isArray: true })
+                @ValidateNested({each:true})
+                members?: Array<Foo>;
+            }
+    `,
+            errors: [
+                {
+                    messageId: "shouldUseTypeDecorator",
+                    suggestions: [
+                        {
+                            messageId: "autofixWithTypeDecorator",
+                            output: `
+            import { ValidateNested } from 'class-validator';
+            
+            export class Foo {}
+            
+            export class CreateOrganisationDto {
+                @Type(() => Foo)@ApiProperty({ type: Person, isArray: true })
+                @ValidateNested({each:true})
+                members?: Array<Foo>;
+            }
+    `,
+                        },
+                    ],
                 },
             ],
         },
@@ -246,6 +311,7 @@ class Foo {
             errors: [
                 {
                     messageId: "shouldUseTypeDecorator",
+                    suggestions: [],
                 },
             ],
         },
@@ -264,6 +330,21 @@ class Foo {
             errors: [
                 {
                     messageId: "shouldUseTypeDecorator",
+                    suggestions: [
+                        {
+                            messageId: "autofixWithTypeDecorator",
+                            output: `
+                import { ValidateNested, IsDate } from 'class-validator';
+                
+                export class CreateOrganisationDto {
+                    @Type(() => Date)@ApiProperty({ type: Person, isArray: true })
+                    @ValidateNested({each:true})
+                    @IsDate()
+                    members!: Date;
+                }
+        `,
+                        },
+                    ],
                 },
             ],
         },
@@ -282,6 +363,21 @@ class Foo {
             errors: [
                 {
                     messageId: "shouldUseTypeDecorator",
+                    suggestions: [
+                        {
+                            messageId: "autofixWithTypeDecorator",
+                            output: `
+                import { ValidateNested, IsDefined } from 'class-validator';
+                
+                export class CreateOrganisationDto {
+                    @Type(() => CustomClass)@ApiProperty({ type: Person, isArray: true })
+                    @ValidateNested({each:true})
+                    @IsDefined()
+                    members!: CustomClass;
+                }
+        `,
+                        },
+                    ],
                 },
             ],
         },

--- a/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
+++ b/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
@@ -193,7 +193,6 @@ const rule = createRule({
                                         ?.typeAnnotation as TSESTree.TSTypeReference
                                 )?.typeParameters?.params;
 
-                                console.log(foundParams);
                                 if (foundParams && foundParams.length === 1) {
                                     const typeName = (
                                         foundParams[0] as TSESTree.TSTypeReference

--- a/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
+++ b/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
@@ -33,7 +33,7 @@ const rule = createRule({
         },
         messages: {
             autofixWithTypeDecorator:
-                "Add @Type({{ typeIdentifier }}) decorator before class property.",
+                "Add @Type(() => {{ typeIdentifier }}) decorator before class property.",
             shouldUseTypeDecorator:
                 "A non-primitive property with validation should probably use a @Type decorator. If this is an enum use @IsEnum().",
         },


### PR DESCRIPTION
## Context
This PR serves to add autofix suggestions for @Type() decorators by suggestion the @Type decorator along with inferred type to add in the.

The autofix suggestion should only show up if type are neither union or intersection types

Got the idea from #36, and had done something similar for a custom eslint plugin in my company. Did an early proof-of-concept along with some test cases.

Will clean up the code if this is a feature you think is worth having!