### PR TITLE
fix: detect null primitive types

### DIFF
--- a/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
+++ b/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
@@ -201,7 +201,6 @@ class Foo {
             // has @IsObject decorator, does not need a Type
             code: `
             import { IsObject } from 'class-validator';
-
             class ExampleDto {
                 @ApiProperty({
                   isArray: true,
@@ -209,6 +208,21 @@ class Foo {
                 @Allow()
                 @IsObject()
                nullExampleProperty!: object
+              }
+    `,
+        },
+        {
+            // is a union between primitive array and null - doesn't need type
+            code: `
+            import { IsString } from 'class-validator';
+
+            class ExampleDto {
+                @ApiProperty({
+                  isArray: true,
+                })
+                @Allow()
+                @IsString({each: true})
+               nullExampleProperty!: string[] | null;
               }
     `,
         },

--- a/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
+++ b/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
@@ -12,6 +12,7 @@ const primitiveTypes = new Set([
     AST_NODE_TYPES.TSStringKeyword,
     AST_NODE_TYPES.TSBooleanKeyword,
     AST_NODE_TYPES.TSNumberKeyword,
+    AST_NODE_TYPES.TSNullKeyword,
 ]);
 export type ValidateNonPrimitivePropertyTypeDecoratorOptions = [
     {


### PR DESCRIPTION
Closes #39 

Thanks again for creating this set of plugins. We're currently using the `validateNonPrimitiveNeedsDecorators` rule and realise that the linter was throwing false positives for matches in #39

This happens because we are not tracking `null` as a primitive type.

Although it might not make sense to send a `null` in the request dto, we were combining both ORM decorators (typeorm) and request validators in our project. As such, a class property could be null for nullable database columns.

Tested and verified that existing logic does not break, and new use case is supported!