### PR TITLE
fix: detect `isObject` decorator usage

### DIFF
--- a/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
+++ b/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
@@ -197,6 +197,21 @@ class Foo {
             }
     `,
         },
+        {
+            // has @IsObject decorator, does not need a Type
+            code: `
+            import { IsObject } from 'class-validator';
+
+            class ExampleDto {
+                @ApiProperty({
+                  isArray: true,
+                })
+                @Allow()
+                @IsObject()
+               nullExampleProperty!: object
+              }
+    `,
+        },
     ],
     invalid: [
         {

--- a/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
+++ b/src/rules/validateNonPrimitvesNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
@@ -33,7 +33,7 @@ const rule = createRule({
         },
         messages: {
             shouldUseTypeDecorator:
-                "A non-primitive property with validation should probably use a @Type decorator. If this is an enum use @IsEnum().",
+                "A non-primitive property with validation should probably use a @Type decorator. If this is an enum use @IsEnum(). If this is a plain object use @IsObject().",
         },
         schema: [
             {
@@ -149,6 +149,17 @@ const rule = createRule({
                 );
 
                 if (hasEnum) {
+                    return;
+                }
+
+                const hasObject = foundClassValidatorDecorators.some(
+                    (foundClassValidatorDecorator) =>
+                        typedTokenHelpers.decoratorIsIsObject(
+                            foundClassValidatorDecorator
+                        )
+                );
+
+                if (hasObject) {
                     return;
                 }
 

--- a/src/utils/typedTokenHelpers.ts
+++ b/src/utils/typedTokenHelpers.ts
@@ -270,7 +270,7 @@ export const typedTokenHelpers = {
 
         return decoratorName === "IsEnum";
     },
-    /** Checks if the decorator is the IsEnum decorator
+    /** Checks if the decorator is the IsObject decorator
      * @param decorator
      */
     decoratorIsIsObject(decorator: TSESTree.Decorator): boolean {

--- a/src/utils/typedTokenHelpers.ts
+++ b/src/utils/typedTokenHelpers.ts
@@ -270,6 +270,14 @@ export const typedTokenHelpers = {
 
         return decoratorName === "IsEnum";
     },
+    /** Checks if the decorator is the IsEnum decorator
+     * @param decorator
+     */
+    decoratorIsIsObject(decorator: TSESTree.Decorator): boolean {
+        const decoratorName = this.getDecoratorName(decorator);
+
+        return decoratorName === "IsObject";
+    },
     /**
      * Gets the name of a decorator
      * Returns null if no name is found


### PR DESCRIPTION
Similar to `@IsEnum`, `@IsObject` should also be ignored from requiring explicit transforms. 

Closes #41 

## Solution
Created a separate function to detect @IsObject decorators similar to IsEnum. Alternatively, we could combine this into one function so that only one conditional check needs to execute. 

Perhaps name it something like areIgnoredDecorators
