### PR TITLE
feat: Add UseGuards detection to controller methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Preventing bugs
 Security
 
 -   should-specify-forbid-unknown-values
+-   api-methods-should-be-guarded
 
 ## Why use this package?
 
@@ -736,5 +737,74 @@ This FAILS - doesn't need isArray
 class TestClass {
     @ApiPropertyOptional({type: String, isArray: true})
     thisIsAProp!: string;
+}
+```
+
+### Rule: api-methods-should-be-guarded
+
+If you require authentication, and don't use a global guard, you should be explicit about how each controller or endpoint is protected, and a UseGuards annotation should cover each.
+
+NOTE: This rule is context-dependent (i.e. it'll generate useless noise if you've got a global guard) and so is OFF by default. It will need manually enabling in the rules section of your eslint config with `"@darraghor/nestjs-typed/api-methods-should-be-guarded": "error"`.
+
+This PASSES - endpoint is protected by an AuthGuard
+
+```ts
+class TestClass {
+    @Get()
+    @UseGuards(AuthGuard('jwt'))
+    public getAll(): Promise<string[]> {
+        return [];
+    }
+}`
+```
+
+This PASSES - entire controller is protected by an AuthGuard
+
+```ts
+@UseGuards(AuthGuard('jwt'))
+class TestClass {
+
+    @Get()
+    public getAll(): Promise<string[]> {
+        return [];
+    }
+
+    @Get()
+    public getOne(): Promise<string> {
+        return "1";
+    }
+}
+```
+
+This PASSES - endpoint is protected by a custom Guard
+
+```ts
+class TestClass {
+    @Post()
+    @UseGuards(MyCustomGuard('hand-gestures'))
+    public getAll(): Promise<string[]> {
+        return [];
+    }
+}
+```
+
+This PASSES - it isn't a controller or an endpoint
+
+```ts
+class TestClass {
+    public getAll(): Promise<string[]> {
+        return [];
+    }
+}
+```
+
+This FAILS - neither the controller nor the endpoint is protected with a guard
+
+```ts
+class TestClass {
+    @Get()
+    public getAll(): Promise<string[]> {
+        return [];
+    }
 }
 ```

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -28,5 +28,6 @@ export = {
             "error",
         "@darraghor/nestjs-typed/all-properties-are-whitelisted": "error",
         "@darraghor/nestjs-typed/all-properties-have-explicit-defined": "error",
+        "@darraghor/nestjs-typed/api-methods-should-be-guarded": "off",
     },
 };

--- a/src/rules/apiMethodsShouldBeGuarded/apiMethodsShouldBeGuarded.test.ts
+++ b/src/rules/apiMethodsShouldBeGuarded/apiMethodsShouldBeGuarded.test.ts
@@ -1,0 +1,97 @@
+import {ESLintUtils} from "@typescript-eslint/utils";
+import {getFixturesRootDirectory} from "../../testing/fixtureSetup";
+import rule from "./apiMethodsShouldBeGuarded";
+
+const tsRootDirectory = getFixturesRootDirectory();
+const ruleTester = new ESLintUtils.RuleTester({
+    parser: "@typescript-eslint/parser",
+    parserOptions: {
+        ecmaVersion: 2015,
+        tsconfigRootDir: tsRootDirectory,
+        project: "./tsconfig.json",
+    },
+});
+
+ruleTester.run("api-methods-should-be-guarded", rule, {
+    valid: [
+        {
+            code: `class TestClass {
+                @Get()
+                @UseGuards(AuthGuard('jwt'))
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+        },
+        {
+            code: `
+                @UseGuards(AuthGuard('jwt'))
+                class TestClass {
+                @Get()
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+        },
+        {
+            code: `class TestClass {
+                @Post()
+                @UseGuards(MyCustomGuard('hand-gestures'))
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+        },
+        {
+            // not an api decorated class
+            code: `class TestClass {
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+        },
+    ],
+    invalid: [
+        {
+            code: `class TestClass {
+                @Get()
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+            errors: [
+                {
+                    messageId: "apiMethodsShouldBeGuarded",
+                },
+            ],
+        },
+        {
+            code: `class TestClass {
+                @All()
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+            errors: [
+                {
+                    messageId: "apiMethodsShouldBeGuarded",
+                },
+            ],
+        },
+        {
+            code: `class TestClass {
+                @Post('can-register')
+                @ApiOperation({ summary: 'Check if registration is available by Company name' })
+                async canRegister(
+                    @Body() { companyName }: CompanyCanRegisterDto,
+                    @Query('countryCode') countryCode?: string,
+                ): Promise<TResultResponse<boolean>> {
+                    const result = await this.companiesService.canRegisterName(companyName, countryCode)
+
+                    return { result }
+                }
+            }`,
+            errors: [{messageId: "apiMethodsShouldBeGuarded"}],
+        },
+    ],
+});

--- a/src/rules/apiMethodsShouldBeGuarded/apiMethodsShouldBeGuarded.ts
+++ b/src/rules/apiMethodsShouldBeGuarded/apiMethodsShouldBeGuarded.ts
@@ -1,0 +1,78 @@
+import {TSESTree, TSESLint} from "@typescript-eslint/utils";
+import {createRule} from "../../utils/createRule";
+import {typedTokenHelpers} from "../../utils/typedTokenHelpers";
+
+export const apiMethodsShouldBeGuarded = (node: TSESTree.MethodDefinition) => {
+    const hasApiMethodDecorator = typedTokenHelpers.nodeHasDecoratorsNamed(
+        node,
+        ["Get", "Post", "Put", "Delete", "Patch", "Options", "Head", "All"]
+    );
+
+    const hasUseGuardsDecorator = typedTokenHelpers.nodeHasDecoratorsNamed(
+        node,
+        ["UseGuards"]
+    );
+
+    function findClassDeclaration(
+        node: TSESTree.Node
+    ): TSESTree.ClassDeclaration | null {
+        if (node.type === "ClassDeclaration") {
+            return node;
+        }
+        if (node.parent) {
+            return findClassDeclaration(node.parent);
+        }
+        return null;
+    }
+
+    const classNode = findClassDeclaration(node);
+
+    const hasUseGuardsDecoratorOnController = classNode
+        ? typedTokenHelpers.nodeHasDecoratorsNamed(classNode, ["UseGuards"])
+        : false;
+
+    return (
+        hasApiMethodDecorator &&
+        !hasUseGuardsDecorator &&
+        !hasUseGuardsDecoratorOnController
+    );
+};
+
+const rule = createRule({
+    name: "api-methods-should-be-guarded",
+    meta: {
+        docs: {
+            description:
+                "Endpoints should have authentication guards to maintain our security model.",
+            recommended: false,
+            requiresTypeChecking: false,
+        },
+        messages: {
+            apiMethodsShouldBeGuarded:
+                "All controller endpoints should have @UseGuards decorators, or one decorating the root of the Controller.",
+        },
+        schema: [],
+        hasSuggestions: false,
+        type: "suggestion",
+    },
+    defaultOptions: [],
+    create(
+        context: Readonly<
+            TSESLint.RuleContext<"apiMethodsShouldBeGuarded", never[]>
+        >
+    ) {
+        return {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            MethodDefinition(node: TSESTree.MethodDefinition): void {
+                if (apiMethodsShouldBeGuarded(node)) {
+                    context.report({
+                        node: node,
+                        messageId: "apiMethodsShouldBeGuarded",
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default rule;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -11,6 +11,7 @@ import validateNonPrimitiveNeedsDecorators from "./validateNonPrimitvesNeedsType
 import validateNestedOfArrayShouldSetEach from "./validateNestedOfArrayShouldSetEach/validateNestedOfArrayShouldSetEach";
 import allPropertiesAreWhitelisted from "./allPropertiesAreWhitelisted/allPropertiesAreWhitelisted";
 import allPropertiesHaveExplicitDefined from "./allPropertiesHaveExplicitDefined/allPropertiesHaveExplicitDefined";
+import apiMethodsShouldBeGuarded from "./apiMethodsShouldBeGuarded/apiMethodsShouldBeGuarded";
 
 const allRules = {
     "all-properties-have-explicit-defined": allPropertiesHaveExplicitDefined,
@@ -33,6 +34,7 @@ const allRules = {
     "validate-nested-of-array-should-set-each":
         validateNestedOfArrayShouldSetEach,
     "all-properties-are-whitelisted": allPropertiesAreWhitelisted,
+    "api-methods-should-be-guarded": apiMethodsShouldBeGuarded,
 };
 
 export default allRules;


### PR DESCRIPTION
## Description

Adds a lint to ensure that any endpoint method has a `@UseGuards` decorator, either at the method or class level.

## Commentary

It's super useful for ensuring correct endpoints have appropriate authentication + authorisation, but it's useless for an open API. 

## Outstanding work

I've added it to Recommended for testing, but I don't think it really belongs there. Could go into Recommended in an "off" state, allowing people to override it?

It doesn't yet have docs - I'll add those as soon as I know where it's going (i.e. that this will be accepted as a PR in some state)