### PR TITLE
fix: typo in jest CLI flag(--colors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "build:ci": "npm run build",
         "build": "npm run clean && mkdir ./dist && tsc --project tsconfig.build.json",
         "lint": "npx eslint -c .eslintrc.js --ext .ts './src/**/*.ts' './tests/**/*.ts' --no-error-on-unmatched-pattern",
-        "test": "export NODE_OPTIONS=\"--max-old-space-size=8192\" && npx jest --runInBand --color --reporters=default --no-cache --coverage=false --silent=false -c jest.config.ts",
+        "test": "export NODE_OPTIONS=\"--max-old-space-size=8192\" && npx jest --runInBand --colors --reporters=default --no-cache --coverage=false --silent=false -c jest.config.ts",
         "pre-commit": "npx lint-staged",
         "prettier": "prettier --write src/*",
         "prepare": "husky install",


### PR DESCRIPTION
It should be `--colors`. Added missing s.
https://jestjs.io/docs/cli#--colors