### PR TITLE
feat: add api-method-should-specify-api-operation rule

### DIFF
--- a/src/configs/noSwagger.ts
+++ b/src/configs/noSwagger.ts
@@ -5,7 +5,8 @@ export = {
     rules: {
         "@darraghor/nestjs-typed/api-property-matches-property-optionality":
             "off",
-        "@darraghor/nestjs-typed/api-method-should-specify-api-response":
+        "@darraghor/nestjs-typed/api-method-should-specify-api-response": "off",
+        "@darraghor/nestjs-typed/api-method-should-specify-api-operation":
             "off",
         "@darraghor/nestjs-typed/controllers-should-supply-api-tags": "off",
         "@darraghor/nestjs-typed/api-enum-property-best-practices": "off",

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -29,5 +29,7 @@ export = {
         "@darraghor/nestjs-typed/all-properties-are-whitelisted": "error",
         "@darraghor/nestjs-typed/all-properties-have-explicit-defined": "error",
         "@darraghor/nestjs-typed/api-methods-should-be-guarded": "off",
+        "@darraghor/nestjs-typed/api-method-should-specify-api-operation":
+            "off",
     },
 };

--- a/src/rules/apiMethodsShouldSpecifyApiOperation/apiMethodsShouldSpecifyApiOperation.test.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiOperation/apiMethodsShouldSpecifyApiOperation.test.ts
@@ -1,0 +1,73 @@
+import {ESLintUtils} from "@typescript-eslint/utils";
+import {getFixturesRootDirectory} from "../../testing/fixtureSetup";
+import rule from "./apiMethodsShouldSpecifyApiOperation";
+
+const tsRootDirectory = getFixturesRootDirectory();
+const ruleTester = new ESLintUtils.RuleTester({
+    parser: "@typescript-eslint/parser",
+    parserOptions: {
+        ecmaVersion: 2015,
+        tsconfigRootDir: tsRootDirectory,
+        project: "./tsconfig.json",
+    },
+});
+
+ruleTester.run("api-method-should-specify-api-operation", rule, {
+    valid: [
+        {
+            code: `class TestClassA {
+                @Get()
+                @ApiOperation({ description: "test description" })
+                @ApiOkResponse({ type: String, isArray: true })
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+        },
+        {
+            code: `class TestClassB {
+                @Get()
+                @ApiOperation({ description: "test description" })
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+        },
+        {
+            // not an api decorated class
+            code: `class TestClassC {
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+        },
+    ],
+    invalid: [
+        {
+            code: `class TestClassD {
+                @Get()
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+            errors: [
+                {
+                    messageId: "shouldSpecifyApiOperation",
+                },
+            ],
+        },
+        {
+            code: `class TestClassE {
+                @All()
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+            errors: [
+                {
+                    messageId: "shouldSpecifyApiOperation",
+                },
+            ],
+        },
+    ],
+});

--- a/src/rules/apiMethodsShouldSpecifyApiOperation/apiMethodsShouldSpecifyApiOperation.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiOperation/apiMethodsShouldSpecifyApiOperation.ts
@@ -1,0 +1,61 @@
+// Import { getParserServices } from "@typescript-eslint/experimental-utils/dist/eslint-utils";
+// import * as tsutils from "tsutils";
+// import { getParserServices } from "@typescript-eslint/experimental-utils/dist/eslint-utils";
+import {TSESTree, TSESLint} from "@typescript-eslint/utils";
+import {createRule} from "../../utils/createRule";
+import {typedTokenHelpers} from "../../utils/typedTokenHelpers";
+
+export const shouldUseApiResponseDecorator = (
+    node: TSESTree.MethodDefinition
+): boolean => {
+    const hasApiMethodDecorator = typedTokenHelpers.nodeHasDecoratorsNamed(
+        node,
+        ["Get", "Post", "Put", "Delete", "Patch", "Options", "Head", "All"]
+    );
+
+    const hasApiOperationDecorator = typedTokenHelpers.nodeHasDecoratorsNamed(
+        node,
+        ["ApiOperation"]
+    );
+
+    return hasApiMethodDecorator && !hasApiOperationDecorator;
+};
+
+const rule = createRule({
+    name: "api-method-should-specify-api-operation",
+    meta: {
+        docs: {
+            description:
+                "Api methods should at least specify the expected ApiOperation.",
+            recommended: false,
+            requiresTypeChecking: false,
+        },
+        messages: {
+            shouldSpecifyApiOperation: `A method decorated with @Get, @Post etc. should specify the expected ApiOperation e.g. @ApiOperation({description: ""}). These decorators are in the @nestjs/swagger npm package.`,
+        },
+        schema: [],
+        hasSuggestions: false,
+        type: "suggestion",
+    },
+    defaultOptions: [],
+
+    create(
+        context: Readonly<
+            TSESLint.RuleContext<"shouldSpecifyApiOperation", never[]>
+        >
+    ) {
+        return {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            MethodDefinition(node: TSESTree.MethodDefinition): void {
+                if (shouldUseApiResponseDecorator(node)) {
+                    context.report({
+                        node: node,
+                        messageId: "shouldSpecifyApiOperation",
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default rule;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -12,6 +12,7 @@ import validateNestedOfArrayShouldSetEach from "./validateNestedOfArrayShouldSet
 import allPropertiesAreWhitelisted from "./allPropertiesAreWhitelisted/allPropertiesAreWhitelisted";
 import allPropertiesHaveExplicitDefined from "./allPropertiesHaveExplicitDefined/allPropertiesHaveExplicitDefined";
 import apiMethodsShouldBeGuarded from "./apiMethodsShouldBeGuarded/apiMethodsShouldBeGuarded";
+import apiMethodsShouldSpecifyApiOperation from "./apiMethodsShouldSpecifyApiOperation/apiMethodsShouldSpecifyApiOperation";
 
 const allRules = {
     "all-properties-have-explicit-defined": allPropertiesHaveExplicitDefined,
@@ -24,7 +25,7 @@ const allRules = {
     "api-method-should-specify-api-response":
         apiMethodsShouldSpecifyApiResponse,
     "api-method-should-specify-api-operation":
-        apiMethodsShouldSpecifyApiResponse,
+        apiMethodsShouldSpecifyApiOperation,
     "api-enum-property-best-practices": apiEnumPropertyBestPractices,
     "api-property-returning-array-should-set-array":
         apiPropertyReturningArrayShouldSetArray,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -23,6 +23,8 @@ const allRules = {
     "controllers-should-supply-api-tags": controllerDecoratedHasApiTags,
     "api-method-should-specify-api-response":
         apiMethodsShouldSpecifyApiResponse,
+    "api-method-should-specify-api-operation":
+        apiMethodsShouldSpecifyApiResponse,
     "api-enum-property-best-practices": apiEnumPropertyBestPractices,
     "api-property-returning-array-should-set-array":
         apiPropertyReturningArrayShouldSetArray,


### PR DESCRIPTION
I discovered in issue history that there was this rule once, but it checked ApiResponses, and was renamed
 
Due to need to cover the whole api with ApiOperations (#52), I present the actual rule for doing this.