### PR TITLE
feat: :sparkles: Handle @ValidateIf like @IsOptional

### DIFF
--- a/src/docs/rules/all-properties-have-explicit-defined.md
+++ b/src/docs/rules/all-properties-have-explicit-defined.md
@@ -1,8 +1,8 @@
 ### Rule: all-properties-have-explicit-defined
 
-This rule checks that all properties of a class have an appropriate `@IsDefined()` or `@IsOptional()` decorator.
+This rule checks that all properties of a class have an appropriate `@IsDefined()`, `@IsOptional()` or `@ValidateIf()` decorator.
 
-This rule also checks that both `@IsDefined()` and `@IsOptional()` are not used on the same property because this doesn't make sense.
+This rule also checks that both `@IsDefined()`, `@IsOptional()` and `@ValidatedIf` are not used on the same property because this doesn't make sense.
 
 The rule will ignore any classes that have 0 class-validator decorators. This is to avoid errors for classes that are not used for validation.
 
@@ -15,6 +15,10 @@ export class CreateOrganisationDto {
 
     @IsOptional()
     someStringProperty?: string;
+
+    @ValidatedIf(o => !o.someStringProperty)
+    @Length(10, 20)
+    someOtherProperty?:  string
 }
 ```
 
@@ -28,7 +32,7 @@ export class CreateOrganisationDto {
 }
 ```
 
-This FAILS - missing `@IsOptional()` on `someStringProperty`
+This FAILS - missing `@IsOptional()` or `ValidateIf()` on `someStringProperty`
 
 ```ts
 export class CreateOrganisationDto {

--- a/src/rules/allPropertiesHaveExplicitDefined/allPropertiesHaveExplicitDefined.spec.ts
+++ b/src/rules/allPropertiesHaveExplicitDefined/allPropertiesHaveExplicitDefined.spec.ts
@@ -109,6 +109,21 @@ class A {
 }
     `,
         },
+
+        {
+            code: `
+import { IsInt, IsOptional, IsString, ValidateIf } from 'class-validator';
+class A {
+  @IsInt()
+  @IsOptional()
+  b?: number
+
+  @ValidateIf((o) => !o.b)
+  @IsString()
+  c?: string
+}
+    `,
+        },
     ],
     invalid: [
         {
@@ -196,7 +211,56 @@ class A {
     `,
             errors: [
                 {
-                    messageId: "conflicting-defined-decorators",
+                    messageId:
+                        "conflicting-defined-decorators-defined-optional",
+                },
+            ],
+        },
+        {
+            code: `
+            import { ValidateIf, IsDefined } from 'class-validator';
+class A {
+  @IsDefined()
+  @ValidateIf()
+  b?: string
+}
+    `,
+            errors: [
+                {
+                    messageId:
+                        "conflicting-defined-decorators-defined-validate-if",
+                },
+            ],
+        },
+        {
+            code: `
+            import { ValidateIf, IsOptional } from 'class-validator';
+class A {
+  @IsOptional()
+  @ValidateIf()
+  b?: string
+}
+    `,
+            errors: [
+                {
+                    messageId:
+                        "conflicting-defined-decorators-optional-validate-if",
+                },
+            ],
+        },
+        {
+            code: `
+            import { ValidateIf, IsOptional, IsDefined } from 'class-validator';
+class A {
+  @IsDefined()
+  @IsOptional()
+  @ValidateIf()
+  b?: string
+}
+    `,
+            errors: [
+                {
+                    messageId: "conflicting-defined-decorators-all",
                 },
             ],
         },


### PR DESCRIPTION
Issue #115 asked for @ValidateIf to be handled in the same manner as @IsOptional. 

This PR implements the requested feature. In addition to adding support for @ValidateIf, it introduces checks for conflicting decorators for all the combinations. 