### PR TITLE
fix: Treat literals like primitives in validated-non-primitive-property-needs-type-decorator

### DIFF
--- a/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
+++ b/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
@@ -174,6 +174,19 @@ class Foo {
         `,
         },
         {
+            // is a literal type
+            code: `
+                import { IsString } from 'class-validator';
+                
+                export class CreateOrganisationDto {
+                    @ApiProperty({ type: Person, isArray: true })
+                    @ValidateNested({each:true})
+                    @IsString()
+                    type!: 'organization'
+                }
+        `,
+        },
+        {
             // is not a primitive type so skip
             code: `
                 import { Allow } from 'class-validator';
@@ -228,6 +241,21 @@ class Foo {
                 @Allow()
                 @IsString({each: true})
                nullExampleProperty!: string[] | null;
+              }
+    `,
+        },
+        {
+            // is a union between literal types - doesn't need type
+            code: `
+            import { IsString } from 'class-validator';
+
+            class ExampleDto {
+                @ApiProperty({
+                  isArray: true,
+                })
+                @Allow()
+                @IsString()
+               nullExampleProperty!: "foo" | "bar";
               }
     `,
         },

--- a/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
+++ b/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
@@ -8,6 +8,7 @@ const primitiveTypes = new Set([
     AST_NODE_TYPES.TSStringKeyword,
     AST_NODE_TYPES.TSBooleanKeyword,
     AST_NODE_TYPES.TSNumberKeyword,
+    AST_NODE_TYPES.TSLiteralType,
     AST_NODE_TYPES.TSNullKeyword,
 ]);
 export type ValidateNonPrimitivePropertyTypeDecoratorOptions = [


### PR DESCRIPTION
Fixes #185.

Treats literal types, e.g. literal strings or literal numbers, as primitives for the purposes of this rule. Properties whose type are a literal type, or are union types containing literal types, no longer trigger the need for `@Type` decorator.

Includes a couple of test cases that used to fail.