### PR TITLE
fix: ignore arrays of `unknown`, `any`, and `object` to fix #184

### DIFF
--- a/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
+++ b/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
@@ -203,7 +203,7 @@ class Foo {
         `,
         },
         {
-            // is an array - should have type and has it so pass!
+            // is an array with both syntaxes - should have type and has it so pass!
             code: `
             import { ValidateNested } from 'class-validator';
             
@@ -211,7 +211,12 @@ class Foo {
                 @ApiProperty({ type: Person, isArray: true })
                 @ValidateNested({each:true})
                 @Type(()=> Foo)
-                members!: Foo[];
+                members1!: Foo[];
+
+                @ApiProperty({ type: Person, isArray: true })
+                @ValidateNested({each:true})
+                @Type(()=> Foo)
+                members2!: Array<Foo>;
             }
     `,
         },
@@ -285,6 +290,69 @@ class Foo {
                 @TransformDate()
                 exampleProperty!: [Date, Date];
               }
+    `,
+        },
+        {
+            // an array of unknown - this is a type that this rule shouldn't care about
+            //https://github.com/darraghoriordan/eslint-plugin-nestjs-typed/issues/184
+            code: `
+            import { Allow } from 'class-validator';
+            
+            export class CreateOrganisationDto {
+                @ApiProperty({
+                  isArray: true,
+                })    
+                @Allow()
+                EXAMPLE1!: unknown[];
+
+                @ApiProperty({
+                  isArray: true,
+                })    
+                @Allow()
+                EXAMPLE2!: Array<unknown>;
+            }
+    `,
+        },
+        {
+            // an array of any - this is a type that this rule shouldn't care about
+            //https://github.com/darraghoriordan/eslint-plugin-nestjs-typed/issues/184
+            code: `
+            import { Allow } from 'class-validator';
+            
+            export class CreateOrganisationDto {
+                @ApiProperty({
+                  isArray: true,
+                })    
+                @Allow()
+                EXAMPLE1!: any[];
+
+                @ApiProperty({
+                  isArray: true,
+                })    
+                @Allow()
+                EXAMPLE2!: Array<any>;
+            }
+    `,
+        },
+        {
+            // an array of any - this is a type that this rule shouldn't care about
+            //https://github.com/darraghoriordan/eslint-plugin-nestjs-typed/issues/184
+            code: `
+            import { Allow } from 'class-validator';
+            
+            export class CreateOrganisationDto {
+                @ApiProperty({
+                  isArray: true,
+                })    
+                @Allow()
+                EXAMPLE1!: object[];
+
+                @ApiProperty({
+                  isArray: true,
+                })    
+                @Allow()
+                EXAMPLE2!: Array<object>;
+            }
     `,
         },
     ],

--- a/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
+++ b/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
@@ -10,6 +10,9 @@ const primitiveTypes = new Set([
     AST_NODE_TYPES.TSNumberKeyword,
     AST_NODE_TYPES.TSLiteralType,
     AST_NODE_TYPES.TSNullKeyword,
+    AST_NODE_TYPES.TSUnknownKeyword,
+    AST_NODE_TYPES.TSAnyKeyword,
+    AST_NODE_TYPES.TSObjectKeyword,
 ]);
 export type ValidateNonPrimitivePropertyTypeDecoratorOptions = [
     {


### PR DESCRIPTION
This should address #184 

It simply adds `unknown`, `any`, and `object` to the list of "primitives" for this rule to ignore.  

I also added tests to check for the `unknown[]` and `Array<unknown>` syntaxes since in my project these would fail in different ways as I was trying to figure this out.