### PR TITLE
New rule: constructor-param-should-be-marked

### DIFF
--- a/src/rules/constructorParamShouldBeMarked/constructorParamShouldBeMarked.test.ts
+++ b/src/rules/constructorParamShouldBeMarked/constructorParamShouldBeMarked.test.ts
@@ -1,0 +1,178 @@
+import rule from "./constructorParamShouldBeMarked";
+import {RuleTester} from "@typescript-eslint/rule-tester";
+
+import {getFixturesRootDirectory} from "../../testing/fixtureSetup";
+import path from "path";
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            ecmaVersion: 2015,
+            tsconfigRootDir: getFixturesRootDirectory(),
+            project: "tsconfig-withMeta.json",
+        },
+    },
+});
+
+ruleTester.run("constructor-param-should-be-marked", rule, {
+    valid: [
+        {
+            code: `
+            import {Injectable} from "./Injectable.stub";
+
+            interface FirstInterface {
+                key: "value"
+            }
+
+            @Injectable()
+            export class MainProvider {
+                private num: number = 5
+
+                constructor(
+                    @Inject("INLINE_FIRST_TOKEN")
+                    private readonly first: FirstInterface,
+                    @Inject("INLINE_SECOND_TOKEN")
+                    private readonly second: number
+                ) {}
+            }
+            `,
+            options: [
+                {
+                    src: [path.join(__dirname + "../../../fixtures", "*.ts")],
+                    filterFromPaths: [
+                        "node_modules",
+                        ".test.",
+                        ".spec.",
+                        "file.ts",
+                    ],
+                },
+            ],
+        },
+        {
+            code: `
+            import {Injectable} from "./Injectable.stub";
+
+            @Injectable()
+            export class FirstProvider {
+                constructor() {}
+            }
+
+            @Injectable()
+            export class MainProvider {
+                constructor(
+                    @Inject(FirstProvider)
+                    private readonly first: FirstProvider
+                ) {}
+            }
+            `,
+            options: [
+                {
+                    src: [path.join(__dirname + "../../../fixtures", "*.ts")],
+                    filterFromPaths: [
+                        "node_modules",
+                        ".test.",
+                        ".spec.",
+                        "file.ts",
+                    ],
+                },
+            ],
+        },
+        {
+            code: `
+            import {Injectable} from "./Injectable.stub";
+
+            const TOKEN = Symbol("token")
+
+            interface FirstInterface {
+                key: "value"
+            }
+
+            @Injectable()
+            export class MainProvider {
+                constructor(
+                    @Inject(TOKEN)
+                    private readonly first: FirstInterface
+                ) {}
+            }
+            `,
+            options: [
+                {
+                    src: [path.join(__dirname + "../../../fixtures", "*.ts")],
+                    filterFromPaths: [
+                        "node_modules",
+                        ".test.",
+                        ".spec.",
+                        "file.ts",
+                    ],
+                },
+            ],
+        },
+    ],
+    invalid: [
+        {
+            code: `
+            import {Injectable} from "./Injectable.stub";
+
+            @Injectable()
+            export class FirstProvider {
+                constructor() {}
+            }
+
+            @Injectable()
+            export class SomeProvider {
+                constructor(
+                    private readonly first: FirstProvider
+                ) {}
+            }
+                `,
+            errors: [{messageId: "injectInConstructor"}],
+            options: [
+                {
+                    src: [path.join(__dirname + "../../../fixtures", "*.ts")],
+                    filterFromPaths: [
+                        "node_modules",
+                        ".test.",
+                        ".spec.",
+                        "file.ts",
+                    ],
+                },
+            ],
+        },
+        {
+            code: `
+            import {Injectable} from "./Injectable.stub";
+
+            @Injectable()
+            export class FirstProvider {
+                constructor() {}
+            }
+
+            @Injectable()
+            export class SecondProvider {
+                constructor() {}
+            }
+
+            @Injectable()
+            export class MainProvider {
+                constructor(
+                    private readonly first: FirstProvider,
+                    @Inject(SecondProvider)
+                    private readonly second: SecondProvider
+                ) {}
+            }
+        `,
+            errors: [{messageId: "injectInConstructor"}],
+            options: [
+                {
+                    src: [path.join(__dirname + "../../../fixtures", "*.ts")],
+                    filterFromPaths: [
+                        "node_modules",
+                        ".test.",
+                        ".spec.",
+                        "file.ts",
+                    ],
+                },
+            ],
+        },
+    ],
+});

--- a/src/rules/constructorParamShouldBeMarked/constructorParamShouldBeMarked.ts
+++ b/src/rules/constructorParamShouldBeMarked/constructorParamShouldBeMarked.ts
@@ -1,0 +1,91 @@
+import {TSESTree} from "@typescript-eslint/utils";
+import {createRule} from "../../utils/createRule";
+import {JSONSchema4TypeName} from "@typescript-eslint/utils/json-schema";
+
+function getConstructor(
+    node: TSESTree.ClassDeclaration
+): TSESTree.MethodDefinition | null {
+    try {
+        return (node.body?.body ?? []).find(
+            (md) =>
+                typeof (md as TSESTree.MethodDefinition).kind !== "undefined" &&
+                (md as TSESTree.MethodDefinition).kind === "constructor"
+        ) as TSESTree.MethodDefinition;
+    } catch (e) {
+        return null;
+    }
+}
+
+function hasDecorators(param: TSESTree.TSParameterProperty) {
+    return param.decorators && param.decorators.length;
+}
+
+const rule = createRule({
+    name: "constructor-param-should-be-marked",
+    meta: {
+        docs: {
+            description:
+                "Constructor should have all dependencies marked with at least one decorator like @Inject() or @InjectRepository() or other similar.",
+        },
+        messages: {
+            injectInConstructor: `Constructor parameters should be marked with @Inject() or similar decorator.`,
+        },
+        schema: [
+            {
+                type: "object" as JSONSchema4TypeName,
+                properties: {
+                    src: {
+                        description:
+                            "files/paths to be analyzed (only for provided injectable or controller)",
+                        type: "array" as JSONSchema4TypeName,
+                        minItems: 1,
+                        items: {
+                            type: "string" as JSONSchema4TypeName,
+                            minLength: 1,
+                        },
+                    },
+                    filterFromPaths: {
+                        description:
+                            "strings to exclude from checks (only for provided injectable or controller)",
+                        type: "array" as JSONSchema4TypeName,
+                        minItems: 1,
+                        items: {
+                            type: "string" as JSONSchema4TypeName,
+                            minLength: 1,
+                        },
+                    },
+                },
+            },
+        ],
+        type: "problem",
+    },
+    defaultOptions: [
+        {
+            src: ["src/**/*.ts"],
+            filterFromPaths: ["dist", "node_modules", ".test.", ".spec."],
+        },
+    ],
+
+    create(context) {
+        return {
+            ClassDeclaration(node: TSESTree.ClassDeclaration): void {
+                const constructor = getConstructor(node);
+
+                if (!constructor) {
+                    return;
+                }
+
+                for (const param of constructor.value.params) {
+                    if (!hasDecorators(param as TSESTree.TSParameterProperty)) {
+                        context.report({
+                            messageId: "injectInConstructor",
+                            node,
+                        });
+                    }
+                }
+            },
+        };
+    },
+});
+
+export default rule;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,4 +1,4 @@
-import injectableShouldBeProvided from "./injectablesShouldBeProvided/injectableShouldBeProvided";
+import injectableShouldBeProvided from "./constructorParamShouldBeMarked/constructorParamShouldBeMarked";
 import providedInjectedShouldMatchFactoryParameters from "./providerInjectedShouldMatchFactory/ProviderInjectedShouldMatchFactory";
 import apiPropertyMatchesPropertyOptionality from "./apiPropertyMatchesPropertyOptionality/apiPropertyMatchesPropertyOptionality";
 import controllerDecoratedHasApiTags from "./controllerDecoratedHasApiTags/controllerDecoratedHasApiTags";
@@ -15,11 +15,14 @@ import apiMethodsShouldBeGuarded from "./apiMethodsShouldBeGuarded/apiMethodsSho
 import apiMethodsShouldSpecifyApiOperation from "./apiMethodsShouldSpecifyApiOperation/apiMethodsShouldSpecifyApiOperation";
 import sortModuleMetadataArrays from "./sortModuleMetadataArrays/sortModuleMetadataArrays";
 import noDuplicateDecorators from "./noDuplicateDecorators/noDuplicateDecorators";
+import constructorParamShouldBeMarked from "./constructorParamShouldBeMarked/constructorParamShouldBeMarked";
+
 const allRules = {
     "all-properties-have-explicit-defined": allPropertiesHaveExplicitDefined,
     "api-property-matches-property-optionality":
         apiPropertyMatchesPropertyOptionality,
     "injectable-should-be-provided": injectableShouldBeProvided,
+    "constructor-param-should-be-marked": constructorParamShouldBeMarked,
     "no-duplicate-decorators": noDuplicateDecorators,
     "provided-injected-should-match-factory-parameters":
         providedInjectedShouldMatchFactoryParameters,


### PR DESCRIPTION
Having this rule will help to establish standard behavior when dealing with a large amount of repositories. Also makes it easier for Nestjs newcomers to understand the injection engine.