### PR TITLE
feat: add support for Sse decorator

### DIFF
--- a/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.test.ts
+++ b/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.test.ts
@@ -254,6 +254,15 @@ ruleTester.run("param-decorator-name-matches-route-param", rule, {
               @Param('id') periodId: string){}
             }`,
         },
+        {
+            // @Sse() decorator is supported
+            code: `
+            export class CustomBotController {
+                @Sse(':chatId/message')
+                async streamMessages(
+                  @Param('chatId') chatId: string){}
+            }`,
+        },
     ],
     invalid: [
         {

--- a/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.ts
+++ b/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.ts
@@ -16,6 +16,7 @@ const nestRequestMethodDecoratorNames = new Set([
     "Options",
     "Head",
     "All",
+    "Sse",
 ]);
 
 export const parsePathParts = (decorator: TSESTree.Decorator): string[] => {


### PR DESCRIPTION
Server-Sent Events (SSE) is a server push technology enabling a client to receive automatic updates from a server via HTTP connection.

In NestJS, `@Sse()` decorator is similar to normal HTTP decorators like `@Get()` or `Post()`, that it supports path variables. This PR provides support for `@Sse()` decorator under `param-decorator-name-matches-route-param` rule.