### PR TITLE
feat: respect ApiExcludeController decorator in api response and tags rules

### DIFF
--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test.ts
@@ -42,6 +42,16 @@ ruleTester.run("api-method-should-specify-api-response", rule, {
                 }
             }`,
         },
+        {
+            // controller with ApiExcludeController
+            code: `@ApiExcludeController()
+            class TestClass {
+                @Get()
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+        },
     ],
     invalid: [
         {

--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
@@ -43,7 +43,18 @@ export const shouldUseApiResponseDecorator = (
         ]
     );
 
-    return hasApiMethodDecorator && !hasApiResponseDecorator;
+    // check if the containing class has ApiExcludeController decorator
+    const containingClass = node.parent?.parent as TSESTree.ClassDeclaration;
+    const hasApiExcludeControllerDecorator =
+        typedTokenHelpers.nodeHasDecoratorsNamed(containingClass, [
+            "ApiExcludeController",
+        ]);
+
+    return (
+        hasApiMethodDecorator &&
+        !hasApiResponseDecorator &&
+        !hasApiExcludeControllerDecorator
+    );
 };
 
 const rule = createRule<[], "shouldSpecifyApiResponse">({

--- a/src/rules/controllerDecoratedHasApiTags/controllerDecoratedHasApiTags.test.ts
+++ b/src/rules/controllerDecoratedHasApiTags/controllerDecoratedHasApiTags.test.ts
@@ -29,6 +29,13 @@ ruleTester.run("controllers-should-supply-api-tags", rule, {
             class TestClass {
           }`,
         },
+        {
+            code: `
+            @ApiExcludeController()
+            @Controller("my-controller")
+            class TestClass {
+          }`,
+        },
     ],
     invalid: [
         {

--- a/src/rules/controllerDecoratedHasApiTags/controllerDecoratedHasApiTags.ts
+++ b/src/rules/controllerDecoratedHasApiTags/controllerDecoratedHasApiTags.ts
@@ -14,7 +14,16 @@ export const shouldUseApiTagDecorator = (
         "ApiTags",
     ]);
 
-    return hasControllerDecorator && !hasApiTagDecorator;
+    const hasApiExcludeControllerDecorator =
+        typedTokenHelpers.nodeHasDecoratorsNamed(node, [
+            "ApiExcludeController",
+        ]);
+
+    return (
+        hasControllerDecorator &&
+        !hasApiTagDecorator &&
+        !hasApiExcludeControllerDecorator
+    );
 };
 
 const rule = createRule<[], "shouldUseApiTagDecorator">({


### PR DESCRIPTION
# Respect ApiExcludeController decorator in API-related rules

## Description
This PR modifies two rules to respect the `@ApiExcludeController()` decorator from `@nestjs/swagger`:

1. `controllers-should-supply-api-tags`
2. `api-method-should-specify-api-response`

Currently, these rules require API documentation decorators even for controllers that are explicitly excluded from Swagger documentation using `@ApiExcludeController()`. This forces developers to either:
- Add unnecessary API documentation decorators to excluded controllers
- Use `eslint-disable` comments to suppress the rules

## Changes
- Modified `controllers-should-supply-api-tags` to skip the `@ApiTags()` requirement for controllers with `@ApiExcludeController()`
- Modified `api-method-should-specify-api-response` to skip the API response decorator requirement for methods in controllers with `@ApiExcludeController()`

## Example
Before:
```typescript
/* eslint-disable @darraghor/nestjs-typed/controllers-should-supply-api-tags */
/* eslint-disable @darraghor/nestjs-typed/api-method-should-specify-api-response */
@Controller()
@ApiExcludeController()
export class PingController {
  @Get('/ping')
  create() {
    return 'pong';
  }
}
```

After:
```typescript
@Controller()
@ApiExcludeController()
export class PingController {
  @Get('/ping')
  create() {
    return 'pong';
  }
}
```

## Testing
Added test cases to verify that:
- Controllers with `@ApiExcludeController()` are not required to have `@ApiTags()`
- Methods in controllers with `@ApiExcludeController()` are not required to have API response decorators
- Regular controllers still require appropriate API documentation decorators

## Impact
This change reduces noise in the codebase by:
- Eliminating unnecessary API documentation decorators
- Removing the need for `eslint-disable` comments
- Making the rules more intuitive by respecting the explicit intention to exclude controllers from API documentation