### PR TITLE
fix(renovate):  HealthCheck as api response decorator

### DIFF
--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
@@ -40,6 +40,7 @@ export const shouldUseApiResponseDecorator = (
             "ApiUnprocessableEntityResponse",
             "ApiUnsupportedMediaTypeResponse",
             "ApiDefaultResponse",
+            "HealthCheck",
         ]
     );
 


### PR DESCRIPTION
This PR setting @HealthCheck() decorator as ApiResponse decorator.
Issue: https://github.com/darraghoriordan/eslint-plugin-nestjs-typed/issues/270