### PR TITLE
fix: #289 for `validated-non-primitive-property-needs-type-decorator` rule

### DIFF
--- a/src/docs/rules/validated-non-primitive-property-needs-type-decorator.md
+++ b/src/docs/rules/validated-non-primitive-property-needs-type-decorator.md
@@ -25,7 +25,7 @@ This rule accepts 2 options:
 This PASSES because we're validating a Person class and we have added the @Type decorator.
 
 ```ts
-export class CreateOrganisationDto {
+export class CreateOrganizationDto {
     @ApiProperty({type: Person, isArray: true})
     @IsDefined()
     @Type(() => Person)
@@ -36,7 +36,7 @@ export class CreateOrganisationDto {
 This PASSES because it is a primitive type (boolean, string, number). We don't need to tell class-transformer how to transform those.
 
 ```ts
-export class CreateOrganisationDto {
+export class CreateOrganizationDto {
     @ApiProperty({type: Person, isArray: true})
     @ValidateNested({each: true})
     @IsBoolean()
@@ -47,7 +47,7 @@ export class CreateOrganisationDto {
 This PASSES because we only check properties that have a class-validator decorator (e.g. `@IsDefined()`)
 
 ```ts
-export class CreateOrganisationDto {
+export class CreateOrganizationDto {
     @ApiProperty({type: Person, isArray: true})
     members!: Person | Date;
 }
@@ -55,31 +55,31 @@ export class CreateOrganisationDto {
 
 This PASSES because it is a primitive array. These don't need `@Type()` decorators.
 
-````ts
+```ts
 class ExampleDto {
     @ApiProperty({
       isArray: true,
     })
     @Allow()
-   exampleProperty!: string[];
+    exampleProperty!: string[];
   }
-    ```
+```
 
 This FAILS because you should always tell class-transformer the type for an array
 
 ```ts
-export class CreateOrganisationDto {
+export class CreateOrganizationDto {
     @ApiProperty({type: Person, isArray: true})
     @ValidateNested({each: true})
     @IsArray()
     members!: (Person | Date)[];
 }
-````
+```
 
 This FAILS because Date is not a primitive type (string, number, boolean)
 
 ```ts
-export class CreateOrganisationDto {
+export class CreateOrganizationDto {
     @ApiProperty({type: Person, isArray: true})
     @ValidateNested({each: true})
     @IsDate()

--- a/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
+++ b/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.test.ts
@@ -356,6 +356,31 @@ class Foo {
             }
     `,
         },
+        {
+            // Shouldn't error out for untyped properties, inferred types, or undecorated properties
+            //https://github.com/darraghoriordan/eslint-plugin-nestjs-typed/issues/289
+            code: `
+            import { Allow } from 'class-validator';
+            
+            export class CreateOrganisationDto {
+                EXAMPLE1 = [];
+                EXAMPLE2: object[] = [];
+                EXAMPLE3: Array<object> = [];
+
+                @ApiProperty({isArray: true })    
+                @Allow()
+                EXAMPLE4 = [];
+
+                @ApiProperty({isArray: true })    
+                @Allow()
+                EXAMPLE5: object[] = [];
+
+                @ApiProperty({isArray: true})    
+                @Allow()
+                EXAMPLE6!: Array<object> = [];
+            }
+    `,
+        },
     ],
     invalid: [
         {

--- a/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
+++ b/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
@@ -101,14 +101,14 @@ const rule = createRule<
                     const mainTypeInShortArray = (
                         node.typeAnnotation
                             ?.typeAnnotation as TSESTree.TSArrayType
-                    ).elementType?.type;
+                    )?.elementType?.type;
 
                     if (!mainTypeInShortArray) {
                         // try to get the type of Array<type> syntax
                         const foundParams = (
                             node.typeAnnotation
                                 ?.typeAnnotation as TSESTree.TSTypeReference
-                        ).typeArguments?.params;
+                        )?.typeArguments?.params;
                         if (foundParams && foundParams.length === 1) {
                             mainType = foundParams[0].type;
                         }


### PR DESCRIPTION
This addresses #289 where the `validated-non-primitive-property-needs-type-decorator` rule would crash when it encountered an array with an inferred type.

Very little code changes needed, but I also added some minor spelling/formatting changes for the related docs.