### PR TITLE
feat: `provided-injected-should-match-factory-parameters` works with modules

### DIFF
--- a/src/rules/providerInjectedShouldMatchFactory/ProviderInjectedShouldMatchFactory.test.ts
+++ b/src/rules/providerInjectedShouldMatchFactory/ProviderInjectedShouldMatchFactory.test.ts
@@ -99,6 +99,15 @@ export default class UserDiscriminatedCacheInterceptor extends CacheInterceptor 
                 });
               };`,
         },
+        // No useFactory found, should be valid
+        {
+            code: `@Module({
+                      providers: [{
+                        provide: MyOtherInjectable,
+                      }],
+                    })
+                    export class JlContractModule {}`,
+        },
     ],
     invalid: [
         {
@@ -128,6 +137,27 @@ export default class UserDiscriminatedCacheInterceptor extends CacheInterceptor 
                 },
                 inject: [MyService],
             };`,
+            errors: [
+                {
+                    messageId: "mainMessage",
+                },
+            ],
+        },
+        // Inline factory in a module provider
+        {
+            code: `@Module({
+                      providers: [{
+                        provide: MyOtherInjectable,
+                        useFactory: async (
+                           config: MyService,
+                           configTwo: MySecondService
+                         ): Promise<MyOtherInjectable> => {
+                         return new MyOtherInjectable()
+                        },
+                        inject: [MyService],
+                      }],
+                    })
+                    export class MyModule {}`,
             errors: [
                 {
                     messageId: "mainMessage",


### PR DESCRIPTION
Currently, the rule `provided-injected-should-match-factory-parameters` only works when you are using a const assignment to declare a module, and thus, is not detecting issues in `@Modules` providers.

```ts
@Module({
  providers: [
    {
      provide: MyOtherInjectable,
      useFactory: async (
        config: MyService,
        configTwo: MySecondService,
      ): Promise<MyOtherInjectable> => {
        return new MyOtherInjectable();
      },
      inject: [MyService],
    },
  ],
})
export class MyModule {}
```

This Pr aims to address this.

- [x] I have added tests to cover a good and bad case
- [x] I have tested this against a real codebase
 
