### PR TITLE
feat: custom api response decorators options

### DIFF
--- a/src/docs/rules/api-method-should-specify-api-response.md
+++ b/src/docs/rules/api-method-should-specify-api-response.md
@@ -4,6 +4,17 @@ If you have an api method like @Get() you should specify the return status code 
 
 Note: I often leave out 400s and 500s because it's kind of assumed, but these decorators should be used if the return type changes in your api for 400/500 etc!
 
+**This rule accepts options:**
+
+- `additionalCustomApiResponseDecorators`: string list of custom api response decorators that will be counted as valid for the rule test e.g.
+
+    ```ts
+    "@darraghor/nestjs-typed/api-method-should-specify-api-response": [
+            "error",
+            {additionalCustomApiResponseDecorators: ["ApiPaginatedResponse"]},
+        ],
+    ```
+
 This PASSES
 
 ```ts

--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.test.ts
@@ -1,6 +1,8 @@
 import {RuleTester} from "@typescript-eslint/rule-tester";
 import {getFixturesRootDirectory} from "../../testing/fixtureSetup.js";
-import rule from "./apiMethodsShouldSpecifyApiResponse.js";
+import rule, {
+    type ApiMethodShouldSpecifyApiResponseOptions,
+} from "./apiMethodsShouldSpecifyApiResponse.js";
 
 const tsRootDirectory = getFixturesRootDirectory();
 const ruleTester = new RuleTester({
@@ -52,6 +54,23 @@ ruleTester.run("api-method-should-specify-api-response", rule, {
                 }
             }`,
         },
+        {
+            // controller with custom response decorator
+            options: [
+                {
+                    additionalCustomApiResponseDecorators: [
+                        "ApiPaginatedResponse",
+                    ],
+                },
+            ] satisfies ApiMethodShouldSpecifyApiResponseOptions,
+            code: `class TestClass {
+                @Get()
+                @ApiPaginatedResponse({ type: TestDto, description: 'Paginated Response' })
+                public getAll(): Promise<PaginatedDto<TestDto>> {
+                    return new PaginatedDto([], 0);
+                }
+            }`,
+        },
     ],
     invalid: [
         {
@@ -70,6 +89,27 @@ ruleTester.run("api-method-should-specify-api-response", rule, {
         {
             code: `class TestClass {
                 @All()
+                public getAll(): Promise<string[]> {
+                    return [];
+                }
+            }`,
+            errors: [
+                {
+                    messageId: "shouldSpecifyApiResponse",
+                },
+            ],
+        },
+        {
+            // controller with custom response decorator
+            options: [
+                {
+                    additionalCustomApiResponseDecorators: [
+                        "ApiPaginatedResponse",
+                    ],
+                },
+            ] satisfies ApiMethodShouldSpecifyApiResponseOptions,
+            code: `class TestClass {
+                @Get()
                 public getAll(): Promise<string[]> {
                     return [];
                 }

--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
@@ -2,8 +2,15 @@ import {TSESTree} from "@typescript-eslint/utils";
 import {createRule} from "../../utils/createRule.js";
 import {typedTokenHelpers} from "../../utils/typedTokenHelpers.js";
 
+export type ApiMethodShouldSpecifyApiResponseOptions = [
+    {
+        additionalCustomApiResponseDecorators: string[];
+    },
+];
+
 export const shouldUseApiResponseDecorator = (
-    node: TSESTree.MethodDefinition
+    node: TSESTree.MethodDefinition,
+    options: ApiMethodShouldSpecifyApiResponseOptions[0]
 ): boolean => {
     const hasApiMethodDecorator = typedTokenHelpers.nodeHasDecoratorsNamed(
         node,
@@ -43,6 +50,12 @@ export const shouldUseApiResponseDecorator = (
         ]
     );
 
+    const hasCustomApiResponseDecorator =
+        typedTokenHelpers.nodeHasDecoratorsNamed(
+            node,
+            options.additionalCustomApiResponseDecorators
+        );
+
     // check if the containing class has ApiExcludeController decorator
     const containingClass = node.parent?.parent as TSESTree.ClassDeclaration;
     const hasApiExcludeControllerDecorator =
@@ -53,11 +66,15 @@ export const shouldUseApiResponseDecorator = (
     return (
         hasApiMethodDecorator &&
         !hasApiResponseDecorator &&
-        !hasApiExcludeControllerDecorator
+        !hasApiExcludeControllerDecorator &&
+        !hasCustomApiResponseDecorator
     );
 };
 
-const rule = createRule<[], "shouldSpecifyApiResponse">({
+const rule = createRule<
+    ApiMethodShouldSpecifyApiResponseOptions,
+    "shouldSpecifyApiResponse"
+>({
     name: "api-method-should-specify-api-response",
     meta: {
         docs: {
@@ -67,16 +84,44 @@ const rule = createRule<[], "shouldSpecifyApiResponse">({
         messages: {
             shouldSpecifyApiResponse: `A method decorated with @Get, @Post etc. should specify the expected ApiResponse e.g. @ApiOkResponse(type: MyType). These decorators are in the @nestjs/swagger npm package.`,
         },
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    additionalCustomApiResponseDecorators: {
+                        description:
+                            "A list of custom api response decorators that this rule will use to validate",
+                        type: "array",
+                        minItems: 0,
+                        items: {
+                            type: "string",
+                            minLength: 1,
+                        },
+                    },
+                },
+            },
+        ],
         hasSuggestions: false,
         type: "suggestion",
     },
-    defaultOptions: [],
+    defaultOptions: [
+        {additionalCustomApiResponseDecorators: new Array<string>()},
+    ],
 
     create(context) {
+        const {additionalCustomApiResponseDecorators} =
+            context.options[0] ||
+            ({
+                additionalCustomApiResponseDecorators: [],
+            } satisfies ApiMethodShouldSpecifyApiResponseOptions[0]);
+
         return {
             MethodDefinition(node: TSESTree.MethodDefinition): void {
-                if (shouldUseApiResponseDecorator(node)) {
+                if (
+                    shouldUseApiResponseDecorator(node, {
+                        additionalCustomApiResponseDecorators,
+                    })
+                ) {
                     context.report({
                         node: node,
                         messageId: "shouldSpecifyApiResponse",


### PR DESCRIPTION
- add `additionalCustomApiResponseDecorators` option to the `api-method-should-specify-api-response` rule 


- [x] add test cases for custom api response decorators
- [x] update rule documentation