### PR TITLE
feat: handle default property initializers in api-property-matches-property-optionality rule

### DIFF
--- a/src/docs/rules/api-property-matches-property-optionality.md
+++ b/src/docs/rules/api-property-matches-property-optionality.md
@@ -1,4 +1,4 @@
-### Rule: api-property-matches-property-optionality
+# Rule: api-property-matches-property-optionality
 
 This checks that you have added the correct api property decorator for your swagger documents.
 
@@ -6,7 +6,9 @@ There are specific, distinct decorators for optional properties and mandatory pr
 
 Using the correct one affects Open Api doc generation.
 
-The following FAILS because this is an optional property and should have `@ApiPropertyOptional`
+## Failing examples
+
+The following FAILS because this is an optional property and should have `@ApiPropertyOptional` — field has `?` but uses `@ApiProperty()`:
 
 ```ts
 class TestClass {
@@ -16,7 +18,7 @@ class TestClass {
 }
 ```
 
-The following FAILS because this is an optional property and should have `@ApiPropertyOptional`
+The following FAILS because this is an optional property (union with undefined) and should have @ApiPropertyOptional:
 
 ```ts
 class TestClass {
@@ -26,12 +28,62 @@ class TestClass {
 }
 ```
 
-The following FAILS because this is a required property and should have `@ApiProperty`. It's not really an optional property but it is from an api DTO transformation perspective.
+New: The following FAILS because a class-field with a default value (initializer) is treated as optional from the DTO/API perspective and therefore should use @ApiPropertyOptional:
+
+```ts
+class TestClass {
+    @Expose()
+    @ApiProperty()
+    thisIsAStringProp: string = "default";
+}
+```
+
+New: The following FAILS because even with an initializer, using the optional modifier together with @ApiProperty() is inconsistent — should be @ApiPropertyOptional:
+
+```ts
+class TestClass {
+    @Expose()
+    @ApiProperty()
+    thisIsAStringProp?: string = "default";
+}
+```
+
+The following FAILS because this is a required property (definite assertion !) and should have @ApiProperty — from DTO transformation perspective it's not optional:
 
 ```ts
 class TestClass {
     @Expose()
     @ApiPropertyOptional()
+    thisIsAStringProp!: string;
+}
+```
+
+## Passing examples (valid)
+
+The rule accepts these:
+
+```ts
+class TestClass {
+    @Expose()
+    @ApiPropertyOptional()
+    thisIsAStringProp?: string;
+}
+
+class TestClass {
+    @Expose()
+    @ApiPropertyOptional()
+    thisIsAStringProp: string | undefined;
+}
+
+class TestClass {
+    @Expose()
+    @ApiPropertyOptional()
+    thisIsAStringProp: string = "default";
+}
+
+class TestClass {
+    @Expose()
+    @ApiProperty()
     thisIsAStringProp!: string;
 }
 ```

--- a/src/rules/apiPropertyMatchesPropertyOptionality/apiPropertyMatchesPropertyOptionality.test.ts
+++ b/src/rules/apiPropertyMatchesPropertyOptionality/apiPropertyMatchesPropertyOptionality.test.ts
@@ -26,6 +26,24 @@ ruleTester.run("api-property-matches-property-optionality", rule, {
                 @ApiPropertyOptional()
                 thisIsAStringProp: string | undefined;}`,
         },
+        {
+            code: `class TestClass {
+                @Expose()
+                @ApiPropertyOptional()
+                thisIsAStringProp?: string = 'default';}`,
+        },
+        {
+            code: `class TestClass {
+                @Expose()
+                @ApiPropertyOptional()
+                thisIsAStringProp: string = 'default';}`,
+        },
+        {
+            code: `class TestClass {
+                @Expose()
+                @ApiProperty()
+                thisIsAStringProp!: string;}`,
+        },
     ],
     invalid: [
         {
@@ -65,6 +83,42 @@ ruleTester.run("api-property-matches-property-optionality", rule, {
             errors: [
                 {
                     messageId: "shouldUseOptionalDecorator",
+                },
+            ],
+        },
+        {
+            code: `class TestClass {
+                @Expose()
+                @ApiProperty()
+                thisIsAStringProp: string = 'default';
+            }`,
+            errors: [
+                {
+                    messageId: "shouldUseOptionalDecorator",
+                },
+            ],
+        },
+        {
+            code: `class TestClass {
+                @Expose()
+                @ApiProperty()
+                thisIsAStringProp?: string = 'default';
+            }`,
+            errors: [
+                {
+                    messageId: "shouldUseOptionalDecorator",
+                },
+            ],
+        },
+        {
+            code: `class TestClass {
+                @Expose()
+                @ApiPropertyOptional()
+                thisIsAStringProp!: string = 'default';
+            }`,
+            errors: [
+                {
+                    messageId: "shouldUseRequiredDecorator",
                 },
             ],
         },

--- a/src/utils/typedTokenHelpers.ts
+++ b/src/utils/typedTokenHelpers.ts
@@ -161,8 +161,14 @@ export const typedTokenHelpers = {
                 (t) => t.type === AST_NODE_TYPES.TSUndefinedKeyword
             ) !== undefined;
 
+        const hasInitializer = node.value !== null && node.value !== undefined;
+
+        const isDefinite = node.definite;
+
         const isOptionalPropertyValue =
-            node.optional || isUndefinedType || false;
+            !isDefinite &&
+            (node.optional || isUndefinedType || hasInitializer || false);
+
         return isOptionalPropertyValue;
     },
     /**


### PR DESCRIPTION
## Changelog
- treat properties with initializers as optional
- replace deprecated `unionTypeParts` by `unionConstituents`

## Check List
- [x] add test cases
- [x] update rule documentation