### PR TITLE
fix: parserOptions deprecation and filter project options for ESLint 9.x

### DIFF
--- a/src/utils/typedTokenHelpers.ts
+++ b/src/utils/typedTokenHelpers.ts
@@ -1,5 +1,5 @@
 import {AST_NODE_TYPES, TSESLint, TSESTree} from "@typescript-eslint/utils";
-import {parse, ParserServices} from "@typescript-eslint/parser";
+import {parse, ParserServices, withoutProjectParserOptions } from "@typescript-eslint/parser";
 import ts from "typescript";
 import * as tsutilsImp from "ts-api-utils";
 
@@ -123,12 +123,14 @@ export const typedTokenHelpers = {
         path: string,
         context: Readonly<TSESLint.RuleContext<never, never[]>>
     ): TSESTree.Program {
+        const parserOptions = withoutProjectParserOptions(context.languageOptions?.parserOptions ?? {});
+        
         return parse(code, {
             filePath: path,
             range: true,
             tokens: true,
             loc: true,
-            ...context.parserOptions,
+            ...parserOptions,
         });
     },
     isEnumType(type: ts.Type) {


### PR DESCRIPTION
The plugin was using the deprecated `context.parserOptions` instead of `context.languageOptions.parserOptions`, [see the documentation](https://eslint.org/docs/latest/extend/custom-rules#the-context-object).

I discovered this issue when creating a new flat config that uses both typescript-eslint's `strictTypeChecked` shared config and this plugin's `flatRecommended` shared config together.

After fixing the first issue, I found it was also passing project-related options (like `project` and `projectService`) to the standalone `parse()` function. These options are meant for ESLint's parser service setup, not for direct parsing, as explained in the [withoutProjectParserOptions documentation](https://typescript-eslint.io/packages/parser/#withoutprojectparseroptionsparseroptions).

I updated the plugin to use `context.languageOptions.parserOptions` and also added `withoutProjectParserOptions` to filter out project-related options that shouldn't be passed to the standalone `parse()` function.

This ensures the plugin correctly reads parser options and works properly alongside strictTypeChecked rules.