### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
+++ b/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts
@@ -87,6 +87,7 @@ const rule = createRule<
         schema: [
             {
                 type: "object",
+                additionalProperties: false,
                 properties: {
                     additionalCustomApiResponseDecorators: {
                         description:

--- a/src/rules/injectablesShouldBeProvided/injectableShouldBeProvided.ts
+++ b/src/rules/injectablesShouldBeProvided/injectableShouldBeProvided.ts
@@ -133,6 +133,7 @@ const rule = createRule<Options, "injectableInModule" | "controllersInModule">({
         schema: [
             {
                 type: "object" as JSONSchema4TypeName,
+                additionalProperties: false,
                 properties: {
                     src: {
                         description:

--- a/src/rules/noDuplicateDecorators/noDuplicateDecorators.ts
+++ b/src/rules/noDuplicateDecorators/noDuplicateDecorators.ts
@@ -25,6 +25,7 @@ const rule = createRule<NoDuplicateDecoratorsOptions, "noDuplicateDecorators">({
         schema: [
             {
                 type: "object" as JSONSchema4TypeName,
+                additionalProperties: false,
                 properties: {
                     customList: {
                         description:

--- a/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.ts
+++ b/src/rules/paramDecoratorNameMatchesRouteParam/paramDecoratorNameMatchesRouteParam.ts
@@ -216,6 +216,7 @@ const rule = createRule<RuleOptions, RuleMessageIds>({
         schema: [
             {
                 type: "object" as JSONSchema4TypeName,
+                additionalProperties: false,
                 properties: {
                     shouldCheckController: {
                         description:

--- a/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
+++ b/src/rules/validateNonPrimitiveNeedsTypeDecorator/validateNonPrimitiveNeedsDecorators.ts
@@ -43,6 +43,7 @@ const rule = createRule<
         schema: [
             {
                 type: "object" as JSONSchema4TypeName,
+                additionalProperties: false,
                 properties: {
                     additionalTypeDecorators: {
                         description:


### PR DESCRIPTION
Some rules, for example [api-method-should-specify-api-response](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed/blob/648e2156732cc354a4079329f0251391a7ddb011/src/rules/apiMethodsShouldSpecifyApiResponse/apiMethodsShouldSpecifyApiResponse.ts#L89) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.