### PR TITLE
feat(api-extra-models): allow direct models annotation on endpoint response type

### DIFF
--- a/src/rules/apiPropertyShouldHaveApiExtraModels/apiPropertyShouldHaveApiExtraModels.test.ts
+++ b/src/rules/apiPropertyShouldHaveApiExtraModels/apiPropertyShouldHaveApiExtraModels.test.ts
@@ -54,6 +54,20 @@ ruleTester.run("api-property-should-have-api-extra-models", rule, {
                 value: any;
             }`,
         },
+        {
+            // with annotation extraModels
+            code: `
+            @ApiExtraModels(Cat, Dog)
+            class TestClass {
+                @ApiProperty({
+                    oneOf: [
+                        { $ref: getSchemaPath(Cat) },
+                        { $ref: getSchemaPath(Dog) },
+                    ],
+                })
+                pet: Cat | Dog;
+            }`,
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
Hello !

## Context

The latest version added a great rule `@darraghor/nestjs-typed/api-property-should-have-api-extra-models` which solves a great pain point. It's hard to spot during review when we missed the `ApiExtraModels`.

In our code base, we always have a response type on our API endpoints, which can reference many sub types. When using `oneOf`, we add `ApiExtraModels` at the top of the endpoint response type.

As per the rule error message `Ensure it is added to @ApiExtraModels() on a controller or included directly in an endpoint response type.`, we were expecting this to be valid:

```
@ApiExtraModels(Cat, Dog)
class TestClass {
    @ApiProperty({
        oneOf: [
            { $ref: getSchemaPath(Cat) },
            { $ref: getSchemaPath(Dog) },
        ],
    })
    pet: Cat | Dog;
}
```

However it is not and it reports error on `Cat` from `getSchemaPath(Cat)` and `Dog` from `getSchemaPath(Dog)`.

## Change summary

My pull request adds a test to cover it, and the implementation to handle that case.

Do you see any edge case I should handle or any flaws in the implementation?

## Out of scope

My change does not handle the other case which could be handle, where the `ApiExtraModel` is set on the controller.