### PR TITLE
`api-enum-property-best-practices` does not validate `@ApiPropertyOptional`

### DIFF
--- a/src/rules/apiEnumPropertyBestPractices/apiEnumPropertyBestPractices.test.ts
+++ b/src/rules/apiEnumPropertyBestPractices/apiEnumPropertyBestPractices.test.ts
@@ -130,5 +130,26 @@ ruleTester.run("api-enum-property-best-practices", rule, {
                 },
             ],
         },
+        {
+            code: `enum MyEnum{
+                ValA,
+                ValB
+            }
+            
+            class MyClass {
+                @ApiPropertyOptional({
+                    type: MyEnum,
+                })
+                public myProperty?:MyEnum
+            }`,
+            errors: [
+                {
+                    messageId: "needsEnumNameAdded",
+                },
+                {
+                    messageId: "needsTypeRemoved",
+                },
+            ],
+        },
     ],
 });


### PR DESCRIPTION
It seems that the `api-enum-property-best-practices` rule is not working for optional properties of type enum. 